### PR TITLE
refactor: execute blurhash calculations immediately

### DIFF
--- a/frappe_blurhash/events/on_file_upload.py
+++ b/frappe_blurhash/events/on_file_upload.py
@@ -6,8 +6,7 @@ from frappe.core.doctype.file.file import get_local_image, get_web_image
 
 
 def on_file_upload(doc, methods=None):
-    frappe.enqueue(set_blur_hash, enqueue_after_commit=True, queue="short",
-                   is_async=False if frappe.flags.in_test else True, doc=doc)
+    frappe.enqueue(set_blur_hash, enqueue_after_commit=True, queue="short", now=True, doc=doc)
 
 
 MAX_RESIZE = (512, 512)


### PR DESCRIPTION
It is totally fine to do this as it take less that a sec to calculate the blurhash after our latest optimizations for images of all sizes..